### PR TITLE
Implement login functionality

### DIFF
--- a/client/src/pages/Login.jsx
+++ b/client/src/pages/Login.jsx
@@ -1,13 +1,32 @@
 import { useState } from 'react';
+import { saveToken } from '../utils/storage.js';
 
 export default function Login() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
 
-  const handleSubmit = (e) => {
+  const [error, setError] = useState(null);
+
+  const handleSubmit = async (e) => {
     e.preventDefault();
-    // TODO: call backend
-    alert(`Login ${email}`);
+    setError(null);
+    try {
+      const res = await fetch('http://localhost:3000/auth/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password })
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        setError(data.error || 'Error de autenticación');
+        return;
+      }
+      const data = await res.json();
+      saveToken(data.token);
+      alert('Sesión iniciada');
+    } catch (err) {
+      setError('No se pudo conectar');
+    }
   };
 
   return (
@@ -16,6 +35,7 @@ export default function Login() {
       <input type="email" value={email} onChange={e => setEmail(e.target.value)} placeholder="email" />
       <input type="password" value={password} onChange={e => setPassword(e.target.value)} placeholder="password" />
       <button type="submit">Entrar</button>
+      {error && <p className="error">{error}</p>}
     </form>
   );
 }

--- a/client/src/utils/storage.js
+++ b/client/src/utils/storage.js
@@ -1,0 +1,13 @@
+export function saveToken(token) {
+  try {
+    localStorage.setItem('jwt', token);
+  } catch {}
+}
+
+export function loadToken() {
+  try {
+    return localStorage.getItem('jwt');
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- add small storage helper for saving/loading JWT
- connect Login page to /auth/login
- show server and network errors

## Testing
- `npm test` (fails: no test specified)
- `npm test` in client directory (fails: missing script)

------
https://chatgpt.com/codex/tasks/task_e_6849e0c4494c832fb835224960370a26