### PR TITLE
Implement JWT login flow

### DIFF
--- a/client/src/api.js
+++ b/client/src/api.js
@@ -1,0 +1,10 @@
+export const API_URL = 'http://localhost:3000';
+
+export async function apiFetch(path, options = {}) {
+  const token = localStorage.getItem('token');
+  const headers = options.headers ? { ...options.headers } : {};
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`;
+  }
+  return fetch(`${API_URL}${path}`, { ...options, headers });
+}

--- a/client/src/pages/Game.jsx
+++ b/client/src/pages/Game.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import Board from '../components/Board.jsx';
+import { apiFetch } from '../api.js';
 
 export default function Game() {
   const [game, setGame] = useState(null);
@@ -8,11 +9,11 @@ export default function Game() {
   useEffect(() => {
     async function startGame() {
       try {
-        const resGame = await fetch('http://localhost:3000/games', { method: 'POST' });
+        const resGame = await apiFetch('/games', { method: 'POST' });
         const createdGame = await resGame.json();
         setGame(createdGame);
 
-        const resPlayer = await fetch(`http://localhost:3000/games/${createdGame.id}/players`, {
+        const resPlayer = await apiFetch(`/games/${createdGame.id}/players`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ name: 'Jugador' })

--- a/client/src/pages/Login.jsx
+++ b/client/src/pages/Login.jsx
@@ -1,13 +1,30 @@
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { apiFetch } from '../api.js';
 
 export default function Login() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const navigate = useNavigate();
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
-    // TODO: call backend
-    alert(`Login ${email}`);
+    try {
+      const res = await apiFetch('/auth/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password })
+      });
+      if (!res.ok) {
+        alert('Credenciales incorrectas');
+        return;
+      }
+      const data = await res.json();
+      localStorage.setItem('token', data.token);
+      navigate('/game');
+    } catch (err) {
+      console.error('Login error', err);
+    }
   };
 
   return (

--- a/client/src/pages/Signup.jsx
+++ b/client/src/pages/Signup.jsx
@@ -1,12 +1,37 @@
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { apiFetch } from '../api.js';
 
 export default function Signup() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const navigate = useNavigate();
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
-    alert(`Registro ${email}`);
+    try {
+      const res = await apiFetch('/auth/signup', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password })
+      });
+      if (!res.ok) {
+        alert('No se pudo registrar');
+        return;
+      }
+      const loginRes = await apiFetch('/auth/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password })
+      });
+      if (loginRes.ok) {
+        const data = await loginRes.json();
+        localStorage.setItem('token', data.token);
+        navigate('/game');
+      }
+    } catch (err) {
+      console.error('Signup error', err);
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary
- add simple api helper for using the JWT token
- implement login/signup calls storing the token
- include Authorization header on game requests

## Testing
- `npm test` in `server` (fails: Error: no test specified)
- `npm test` in `client` (fails: missing script)


------
https://chatgpt.com/codex/tasks/task_e_6849e0c2cf40832f867119674ae7e60f