### PR TITLE
Optimize server Docker build

### DIFF
--- a/server/.dockerignore
+++ b/server/.dockerignore
@@ -1,0 +1,9 @@
+node_modules
+test
+.git
+.gitignore
+Dockerfile
+.dockerignore
+npm-debug.log*
+README.md
+.env

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,6 +1,6 @@
-FROM node:20
+FROM node:20-alpine
 WORKDIR /app
 COPY package*.json ./
-RUN npm install
+RUN npm ci --omit=dev
 COPY . .
 CMD ["node", "app.js"]

--- a/server/README.md
+++ b/server/README.md
@@ -60,6 +60,14 @@ Build and run with docker-compose to start the API and a PostgreSQL database:
 docker-compose up --build
 ```
 
+The Docker image is now based on the lightweight `node:20-alpine` image and uses
+`npm ci --omit=dev` to install only production dependencies. This makes the
+resulting container much smaller. You can build it directly with:
+
+```bash
+docker build -t snakes-ladders-api .
+```
+
 The API will be available on port `3000`.
 
 ### Deployment


### PR DESCRIPTION
## Summary
- ignore development files when building the server image
- use a lightweight Node image and only install production deps
- document the smaller image and how to build it

## Testing
- `npm test --prefix server`

------
https://chatgpt.com/codex/tasks/task_e_684b2d1b4060832faef2742c11812511